### PR TITLE
[iOS] get all exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ CookieManager.get('http://example.com')
   });
 
 // list cookies (IOS ONLY)
-CookieManager.getAll()
+// useWebKit: boolean
+CookieManager.getAll(useWebKit)
   .then((res) => {
     console.log('CookieManager.getAll =>', res);
   });

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -230,21 +230,6 @@ RCT_EXPORT_METHOD(
     }
 }
 
-RCT_EXPORT_METHOD(getAll:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject) {
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSMutableDictionary *cookies = [NSMutableDictionary dictionary];
-    for (NSHTTPCookie *c in cookieStorage.cookies) {
-        NSMutableDictionary *d = [NSMutableDictionary dictionary];
-        [d setObject:c.value forKey:@"value"];
-        [d setObject:c.name forKey:@"name"];
-        [d setObject:c.domain forKey:@"domain"];
-        [d setObject:c.path forKey:@"path"];
-        [d setObject:[self.formatter stringFromDate:c.expiresDate] forKey:@"expiresDate"];
-        [cookies setObject:d forKey:c.name];
-    }
-}
-
 -(NSDictionary *)createCookieList:(NSArray<NSHTTPCookie *>*)cookies
 {
     NSMutableDictionary *cookieList = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Addressing issue: https://github.com/safaiyeh/react-native-cookie-store/issues/4

the non-WebKit getAll implementation caused an exception to throw. Removing it fixes it.